### PR TITLE
implement tables() and views() methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/mysql",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/mysql",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mysql",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "MOST Web Framework MySQL Data Adapter",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/spec/MySqlAdapter.spec.js
+++ b/spec/MySqlAdapter.spec.js
@@ -36,6 +36,26 @@ describe('MySqlAdapter', () => {
         });
     });
 
+    it('should get tables', async () => {
+        await app.executeInTestTranscaction(async (context) => {
+            const tables = await context.db.tables().listAsync();
+            expect(Array.isArray(tables)).toBeTruthy();
+            expect(tables.length).toBeGreaterThan(0);
+            const table1 = tables.find((table) => table.name === 'UserBase');
+            expect(table1).toBeTruthy();
+        });
+    });
+
+    it('should get views', async () => {
+        await app.executeInTestTranscaction(async (context) => {
+            const views = await context.db.views().listAsync();
+            expect(Array.isArray(views)).toBeTruthy();
+            expect(views.length).toBeGreaterThan(0);
+            const view1 = views.find((table) => table.name === 'UserData');
+            expect(view1).toBeTruthy();
+        });
+    });
+
     it('should create table', async () => {
         await app.executeInTestTranscaction(async (context) => {
             const db = context.db;

--- a/src/MySqlAdapter.d.ts
+++ b/src/MySqlAdapter.d.ts
@@ -2,6 +2,16 @@ import { DataAdapterBase, DataAdapterBaseHelper } from '@themost/common';
 import { AsyncSeriesEventEmitter } from '@themost/events';
 import { SqlFormatter } from '@themost/query';
 
+export declare interface DataAdapterTables {
+    list(callback: (err: Error, result: { name: string }[]) => void): void;
+    listAsync(): Promise<{ name: string }[]>;
+}
+
+export declare interface DataAdapterViews {
+    list(callback: (err: Error, result: { name: string }[]) => void): void;
+    listAsync(): Promise<{ name: string }[]>;
+}
+
 export declare class MySqlAdapter implements DataAdapterBase, DataAdapterBaseHelper {
     executing: AsyncSeriesEventEmitter<{target: SqliteAdapter, query: (string|QueryExpression), params?: unknown[]}>;
     executed: AsyncSeriesEventEmitter<{target: SqliteAdapter, query: (string|QueryExpression), params?: unknown[], results: uknown[]}>;
@@ -26,6 +36,8 @@ export declare class MySqlAdapter implements DataAdapterBase, DataAdapterBaseHel
     executeAsync(query: any, values: any): Promise<any>;
     table(name: string): MySqlAdapterTable;
     view(name: string): MySqlAdapterView;
+    tables(): DataAdapterTables;
+    views(): DataAdapterViews;
     indexes(name: string): MySqlAdapterIndexes;
     database(name: string): MySqlAdapterDatabase;
     getFormatter(): SqlFormatter;

--- a/src/MySqlAdapter.js
+++ b/src/MySqlAdapter.js
@@ -992,6 +992,56 @@ class MySqlAdapter {
         };
     }
 
+    tables() {
+        const self = this;
+        return {
+            list: function (callback) {
+                self.execute('SELECT `TABLE_NAME` AS `name` FROM `information_schema`.`TABLES` WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_TYPE`=\'BASE TABLE\'', null, function (err, results) {
+                    if (err) {
+                        return callback(err);
+                    }
+                    return callback(null, results);
+                });
+            },
+            listAsync: function () {
+                const thisArg = this;
+                return new Promise((resolve, reject) => {
+                    thisArg.list((err, results) => {
+                        if (err) {
+                            return reject(err);
+                        }
+                        return resolve(results);
+                    });
+                });
+            }
+        }
+    }
+
+    views() {
+        const self = this;
+        return {
+            list: function (callback) {
+                self.execute('SELECT `TABLE_NAME` AS `name` FROM `information_schema`.`TABLES` WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_TYPE`=\'VIEW\'', null, function (err, results) {
+                    if (err) {
+                        return callback(err);
+                    }
+                    return callback(null, results);
+                });
+            },
+            listAsync: function () {
+                const thisArg = this;
+                return new Promise((resolve, reject) => {
+                    thisArg.list((err, results) => {
+                        if (err) {
+                            return reject(err);
+                        }
+                        return resolve(results);
+                    });
+                });
+            }
+        }
+    }
+
     indexes(table) {
         const self = this;
         const formatter = self.getFormatter();


### PR DESCRIPTION
This PR implements `MySqlAdapter.tables()` and `MySqlAdapter.views()` for enumerating tables and views of a mysql db.

```javascript
const tables = await context.db.tables().listAsync();
```

or

```javascript
const views = await context.db.views().listAsync();
```